### PR TITLE
Remove findDOMNode usage at all

### DIFF
--- a/lib/HandleBar.js
+++ b/lib/HandleBar.js
@@ -11,13 +11,12 @@ var __extends = (this && this.__extends) || (function () {
 })();
 Object.defineProperty(exports, "__esModule", { value: true });
 var React = require("react");
-var ReactDOM = require("react-dom");
 var HandleBar = /** @class */ (function (_super) {
     __extends(HandleBar, _super);
     function HandleBar() {
         var _this = _super !== null && _super.apply(this, arguments) || this;
         _this.getDivInstance = function () {
-            return ReactDOM.findDOMNode(_this.div);
+            return _this.div;
         };
         return _this;
     }

--- a/lib/Pane.js
+++ b/lib/Pane.js
@@ -11,13 +11,12 @@ var __extends = (this && this.__extends) || (function () {
 })();
 Object.defineProperty(exports, "__esModule", { value: true });
 var React = require("react");
-var ReactDOM = require("react-dom");
 var Pane = /** @class */ (function (_super) {
     __extends(Pane, _super);
     function Pane() {
         var _this = _super !== null && _super.apply(this, arguments) || this;
         _this.getDivInstance = function () {
-            return ReactDOM.findDOMNode(_this.div);
+            return _this.div;
         };
         return _this;
     }

--- a/lib/Splitter.js
+++ b/lib/Splitter.js
@@ -11,7 +11,6 @@ var __extends = (this && this.__extends) || (function () {
 })();
 Object.defineProperty(exports, "__esModule", { value: true });
 var React = require("react");
-var ReactDOM = require("react-dom");
 /********************************
 * import files needed for splitter to work
 ********************************/
@@ -146,7 +145,9 @@ var Splitter = /** @class */ (function (_super) {
             var maxMousePosition;
             var nodeWrapperSize;
             var primaryPaneOffset;
-            var wrapper = ReactDOM.findDOMNode(_this.paneWrapper).getBoundingClientRect();
+            if (!_this.paneWrapper)
+                return;
+            var wrapper = _this.paneWrapper.getBoundingClientRect();
             var primaryPane = _this.panePrimary.getDivInstance().getBoundingClientRect();
             var handleBarSize = _this.handlebar.getDivInstance().getBoundingClientRect();
             var posInHandleBar = _this.props.position === 'vertical'

--- a/src/components/Splitters/HandleBar.tsx
+++ b/src/components/Splitters/HandleBar.tsx
@@ -1,5 +1,4 @@
 import * as React from 'react';
-import * as ReactDOM from 'react-dom';
 
 import { HandleBarProps } from './typings/index';
 
@@ -32,7 +31,7 @@ class HandleBar extends React.Component<HandleBarProps, {}> {
     }
 
     getDivInstance = () => {
-        return ReactDOM.findDOMNode(this.div);
+        return this.div;
     }
 }
 

--- a/src/components/Splitters/Pane.tsx
+++ b/src/components/Splitters/Pane.tsx
@@ -1,5 +1,4 @@
 import * as React from 'react';
-import * as ReactDOM from 'react-dom';
 
 import { PaneProps } from './typings/index';
 
@@ -28,7 +27,7 @@ class Pane extends React.Component<PaneProps, {}> {
     }
 
     getDivInstance = () => {
-        return ReactDOM.findDOMNode(this.div);
+        return this.div;
     }
 }
 

--- a/src/components/Splitters/Splitter.tsx
+++ b/src/components/Splitters/Splitter.tsx
@@ -1,5 +1,4 @@
 import * as React from 'react';
-import * as ReactDOM from 'react-dom';
 /********************************
 * import files needed for splitter to work
 ********************************/
@@ -340,7 +339,9 @@ export class Splitter extends React.Component<SplitterProps, SplitterState> {
         let maxMousePosition;
         let nodeWrapperSize;
         let primaryPaneOffset;
-        let wrapper = ReactDOM.findDOMNode(this.paneWrapper).getBoundingClientRect();
+        if (!this.paneWrapper)
+            return;
+        let wrapper = this.paneWrapper.getBoundingClientRect();
         let primaryPane = this.panePrimary.getDivInstance().getBoundingClientRect();
         let handleBarSize = this.handlebar.getDivInstance().getBoundingClientRect();
 


### PR DESCRIPTION
findDOMNode is pointless because you're calling it on something that is already a DOM node, so it can be safely removed. This commit will also fix your issue #9 which I also sometimes encounter in my projects (however it seems it's harmless because it only occurs during mount/unmount)